### PR TITLE
ci: add automatic release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: stable
+      
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
Add GitHub Actions workflow for automatic releases using GoReleaser.

## Changes
- Create `.github/workflows/release.yml`
- Trigger on tag push (v* pattern)
- Use GoReleaser GitHub Action v6
- Automatically build and release binaries for all platforms

## How to Use
After this PR is merged, releases will be automated:
1. Create a new tag: `git tag -a v0.3.0 -m "Release v0.3.0"`
2. Push the tag: `git push origin v0.3.0`
3. GitHub Actions will automatically:
   - Build binaries for all platforms
   - Create GitHub Release
   - Upload binaries with correct naming for gh extension

## Benefits
- No manual release process
- Consistent release artifacts
- Reduced human error
- Faster release cycle