### PR TITLE
docs: clarify usage examples in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,13 +41,13 @@ gh extension upgrade sub-issue
 Link an existing issue to a parent issue:
 
 ```bash
-# Using issue numbers
+# Using issue numbers (add existing issue 456 as sub-issue of parent 123)
 gh sub-issue add 123 456
 
-# Using URLs
+# Using URLs (parent issue URL, existing issue number)
 gh sub-issue add https://github.com/owner/repo/issues/123 456
 
-# Cross-repository
+# Cross-repository (add existing issue 456 as sub-issue of parent 123)
 gh sub-issue add 123 456 --repo owner/repo
 ```
 


### PR DESCRIPTION
Fixes #57

## Changes
- Add clarifying comments to usage examples showing which issue becomes the sub-issue
- Make it clear that existing issues are being linked as sub-issues of parent issues

## Before
```bash
# Using issue numbers
gh sub-issue add 123 456
```

## After
```bash
# Using issue numbers (add existing issue 456 as sub-issue of parent 123)
gh sub-issue add 123 456
```

This addresses the confusion about which argument is the parent and which becomes the sub-issue.