### PR TITLE
fix: add empty result handling to formatPlain function

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -499,13 +499,28 @@ func formatTTY(result *ListResult) string {
 // formatPlain formats output as plain text (tab-separated)
 func formatPlain(result *ListResult) string {
 	var output strings.Builder
-	
+
+	// Handle empty result
+	if result.Total == 0 {
+		var emptyMessage string
+		switch listRelationFlag {
+		case "parent":
+			emptyMessage = "No parent issue found."
+		case "siblings":
+			emptyMessage = "No sibling issues found."
+		default: // "children" or default case
+			emptyMessage = "No sub-issues found."
+		}
+		output.WriteString(emptyMessage + "\n")
+		return output.String()
+	}
+
 	for _, issue := range result.SubIssues {
 		assignees := strings.Join(issue.Assignees, ",")
-		output.WriteString(fmt.Sprintf("%d\t%s\t%s\t%s\n", 
+		output.WriteString(fmt.Sprintf("%d\t%s\t%s\t%s\n",
 			issue.Number, issue.State, issue.Title, assignees))
 	}
-	
+
 	return output.String()
 }
 

--- a/cmd/list_test.go
+++ b/cmd/list_test.go
@@ -49,37 +49,101 @@ func TestTruncate(t *testing.T) {
 }
 
 func TestFormatPlain(t *testing.T) {
-	result := &ListResult{
-		Parent: ParentIssue{
-			Number: 1,
-			Title:  "Parent Issue",
-			State:  "open",
-		},
-		SubIssues: []SubIssue{
-			{
-				Number:    2,
-				Title:     "First sub-issue",
-				State:     "open",
-				URL:       "https://github.com/owner/repo/issues/2",
-				Assignees: []string{"user1", "user2"},
+	tests := []struct {
+		name             string
+		result           *ListResult
+		relationFlag     string
+		expected         string
+	}{
+		{
+			name: "with sub-issues",
+			result: &ListResult{
+				Parent: ParentIssue{
+					Number: 1,
+					Title:  "Parent Issue",
+					State:  "open",
+				},
+				SubIssues: []SubIssue{
+					{
+						Number:    2,
+						Title:     "First sub-issue",
+						State:     "open",
+						URL:       "https://github.com/owner/repo/issues/2",
+						Assignees: []string{"user1", "user2"},
+					},
+					{
+						Number:    3,
+						Title:     "Second sub-issue",
+						State:     "closed",
+						URL:       "https://github.com/owner/repo/issues/3",
+						Assignees: []string{},
+					},
+				},
+				Total:     2,
+				OpenCount: 1,
 			},
-			{
-				Number:    3,
-				Title:     "Second sub-issue",
-				State:     "closed",
-				URL:       "https://github.com/owner/repo/issues/3",
-				Assignees: []string{},
-			},
+			relationFlag: "children",
+			expected:     "2\topen\tFirst sub-issue\tuser1,user2\n3\tclosed\tSecond sub-issue\t\n",
 		},
-		Total:     2,
-		OpenCount: 1,
+		{
+			name: "empty result - children",
+			result: &ListResult{
+				Parent: ParentIssue{
+					Number: 1,
+					Title:  "Parent Issue",
+					State:  "open",
+				},
+				SubIssues: []SubIssue{},
+				Total:     0,
+				OpenCount: 0,
+			},
+			relationFlag: "children",
+			expected:     "No sub-issues found.\n",
+		},
+		{
+			name: "empty result - parent",
+			result: &ListResult{
+				Parent: ParentIssue{
+					Number: 1,
+					Title:  "Current Issue",
+					State:  "open",
+				},
+				SubIssues: []SubIssue{},
+				Total:     0,
+				OpenCount: 0,
+			},
+			relationFlag: "parent",
+			expected:     "No parent issue found.\n",
+		},
+		{
+			name: "empty result - siblings",
+			result: &ListResult{
+				Parent: ParentIssue{
+					Number: 1,
+					Title:  "Current Issue",
+					State:  "open",
+				},
+				SubIssues: []SubIssue{},
+				Total:     0,
+				OpenCount: 0,
+			},
+			relationFlag: "siblings",
+			expected:     "No sibling issues found.\n",
+		},
 	}
 
-	expected := "2\topen\tFirst sub-issue\tuser1,user2\n3\tclosed\tSecond sub-issue\t\n"
-	output := formatPlain(result)
-	
-	if output != expected {
-		t.Errorf("formatPlain() output mismatch\nGot:\n%s\nExpected:\n%s", output, expected)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set the global flag for the test
+			originalFlag := listRelationFlag
+			listRelationFlag = tt.relationFlag
+			defer func() { listRelationFlag = originalFlag }()
+
+			output := formatPlain(tt.result)
+			if output != tt.expected {
+				t.Errorf("formatPlain() output mismatch\nGot:\n%s\nExpected:\n%s", output, tt.expected)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary
- Fixes #84 - list command now displays appropriate messages when no issues match the filter
- Adds empty result handling to `formatPlain()` function for non-TTY environments
- Ensures consistent behavior between TTY and non-TTY output formats

## Problem
When using `gh sub-issue list` with the default `--state open` filter, if all sub-issues are closed, the command returned **no output** instead of displaying an informative message. This was particularly confusing in CI/CD environments and scripts where `formatPlain()` is used.

## Solution
Added empty result handling in `formatPlain()` similar to the existing implementation in `formatTTY()`:
- Detects when `result.Total == 0`
- Displays context-appropriate messages based on relation type:
  - "No sub-issues found." for children (default)
  - "No parent issue found." for parent
  - "No sibling issues found." for siblings

## Test Plan
✅ Manually tested with closed sub-issues - now shows "No sub-issues found."
✅ Verified `--state all` still displays all issues correctly
✅ Tested parent and siblings relations - show appropriate messages
✅ All existing tests pass (`go test ./cmd -v`)

## Before/After

**Before:**
```bash
$ gh sub-issue list 403  # Has only closed sub-issues
[No output]
```

**After:**
```bash
$ gh sub-issue list 403  # Has only closed sub-issues
No sub-issues found.
```

Closes #84

🤖 Generated with Claude Code